### PR TITLE
made landing page animation work with mobile screens

### DIFF
--- a/my-app/src/sections/SolariDisplay.css
+++ b/my-app/src/sections/SolariDisplay.css
@@ -4,8 +4,8 @@
     display: flex;
     flex-direction: column;      
     justify-content: center;     
-    align-items: center;         
-    gap: 10px;                   
+    align-items: center;    
+    gap: 10px;
     padding: 20px;              
     margin: 0 auto;              
     
@@ -33,7 +33,8 @@
   @media (max-width: 600px) {
     .solari-display {
       height: 250px;            
-      padding: 10px;           
+      padding: 10px;   
+      margin-top: 100px;        
     }
   
     .solari-word {


### PR DESCRIPTION
Pull Request:

 /* Responsive Adjustments */
  @media (max-width: 600px) {
    .solari-display {
      height: 250px;            
      padding: 10px;   
      margin-top: 100px;        
    }
    
    added margin-top: 100px; to account for height of navbar when media is small screen.
    normal website view still the same.

<img width="577" alt="Screenshot 2025-02-04 at 12 39 58 AM" src="https://github.com/user-attachments/assets/f858ee80-9497-4fd1-9aaa-869a6c02b540" />
